### PR TITLE
feat(upload): add wiki link detection

### DIFF
--- a/client/features/upload-form/components/MarkdownParser.tsx
+++ b/client/features/upload-form/components/MarkdownParser.tsx
@@ -1,0 +1,63 @@
+import { type MarkdownMetadata, markdownToHtml } from "@shared/utils/markdown";
+import { useEffect, useRef } from "react";
+
+export type ParsedMarkdown = {
+	markdown: string;
+	html: string;
+	metadata: MarkdownMetadata;
+};
+
+interface MarkdownParserProps {
+	file: File | null;
+	onParsed: (parsed: ParsedMarkdown | null) => void;
+	onLoadingChange: (isLoading: boolean) => void;
+}
+
+export function MarkdownParser({
+	file,
+	onParsed,
+	onLoadingChange,
+}: MarkdownParserProps) {
+	const requestIdRef = useRef(0);
+
+	useEffect(() => {
+		if (!file) {
+			onLoadingChange(false);
+			onParsed(null);
+			return;
+		}
+
+		requestIdRef.current += 1;
+		const requestId = requestIdRef.current;
+		let isCancelled = false;
+
+		const parse = async () => {
+			try {
+				onLoadingChange(true);
+				const markdown = await file.text();
+				if (isCancelled || requestId !== requestIdRef.current) return;
+
+				const { html, metadata } = await markdownToHtml(markdown);
+				if (isCancelled || requestId !== requestIdRef.current) return;
+
+				onParsed({ markdown, html, metadata });
+			} catch (error) {
+				if (isCancelled || requestId !== requestIdRef.current) return;
+				console.error("Failed to parse markdown:", error);
+				onParsed(null);
+			} finally {
+				if (!isCancelled && requestId === requestIdRef.current) {
+					onLoadingChange(false);
+				}
+			}
+		};
+
+		void parse();
+
+		return () => {
+			isCancelled = true;
+		};
+	}, [file, onParsed, onLoadingChange]);
+
+	return null;
+}

--- a/client/features/upload-form/components/PreviewDialog.tsx
+++ b/client/features/upload-form/components/PreviewDialog.tsx
@@ -3,22 +3,23 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback } from "react";
 import { cn } from "@/utils/styles";
 import { usePreview } from "../hooks/usePreview";
+import type { ParsedMarkdown } from "./MarkdownParser";
 
 interface PreviewDialogProps {
-	file: File;
+	parsed: ParsedMarkdown | null;
 	theme: string;
 	expirationDays: number;
 	onClose: () => void;
 }
 
 export function PreviewDialog({
-	file,
+	parsed,
 	theme,
 	expirationDays,
 	onClose,
 }: PreviewDialogProps) {
 	const { loading, error, iframeRef, themeName } = usePreview({
-		file,
+		parsed,
 		theme,
 		expirationDays,
 	});

--- a/client/features/upload-form/components/PreviewPane.tsx
+++ b/client/features/upload-form/components/PreviewPane.tsx
@@ -3,9 +3,10 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect } from "react";
 import { cn } from "@/utils/styles";
 import { usePreview } from "../hooks/usePreview";
+import type { ParsedMarkdown } from "./MarkdownParser";
 
 interface PreviewPaneProps {
-	file: File;
+	parsed: ParsedMarkdown | null;
 	theme: string;
 	expirationDays: number;
 	onClose: () => void;
@@ -13,14 +14,14 @@ interface PreviewPaneProps {
 }
 
 export function PreviewPane({
-	file,
+	parsed,
 	theme,
 	expirationDays,
 	onClose,
 	onLoadingChange,
 }: PreviewPaneProps) {
 	const { loading, iframeRef, themeName } = usePreview({
-		file,
+		parsed,
 		theme,
 		expirationDays,
 	});

--- a/client/features/upload-form/components/UploadView.tsx
+++ b/client/features/upload-form/components/UploadView.tsx
@@ -19,6 +19,7 @@ interface UploadViewProps {
 	selectedTheme: string;
 	isUploading: boolean;
 	uploadError: string | null;
+	hasWikiLink: boolean;
 	fileInputRef: RefObject<HTMLInputElement | null>;
 	isPreviewOpen: boolean;
 	isPreviewLoading: boolean;
@@ -37,6 +38,7 @@ export function UploadView({
 	selectedTheme,
 	isUploading,
 	uploadError,
+	hasWikiLink,
 	fileInputRef,
 	isPreviewOpen,
 	isPreviewLoading,
@@ -199,6 +201,25 @@ export function UploadView({
 					)}
 				</div>
 			</div>
+
+			{hasWikiLink && (
+				<div className="mt-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3.5 py-2.5 text-left">
+					<div className="flex items-start gap-2.5">
+						<HugeiconsIcon
+							icon={Alert01Icon}
+							className="mt-0.5 h-4 w-4 text-amber-400"
+						/>
+						<div className="text-[12.5px] leading-relaxed text-amber-100/95">
+							<div className="font-medium text-amber-200">
+								{t("upload.wikiLinkWarningTitle")}
+							</div>
+							<div className="text-amber-100/85">
+								{t("upload.wikiLinkWarningBody")}
+							</div>
+						</div>
+					</div>
+				</div>
+			)}
 
 			<div className="block mt-4 px-1">
 				<div className="flex justify-between items-baseline mb-2">

--- a/client/lib/i18nResources.ts
+++ b/client/lib/i18nResources.ts
@@ -51,6 +51,9 @@ export const resources = {
 				closePreview: "Close Preview",
 				tryLater: "Try later",
 				createPage: "Create Page",
+				wikiLinkWarningTitle: "Wiki links detected",
+				wikiLinkWarningBody:
+					"External URLs inside wiki links won't be turned into pages here.",
 			},
 			userMenu: {
 				dashboard: "Dashboard",
@@ -135,6 +138,9 @@ export const resources = {
 				closePreview: "미리보기 닫기",
 				tryLater: "나중에 다시 시도",
 				createPage: "페이지 만들기",
+				wikiLinkWarningTitle: "위키 링크가 감지되었어요",
+				wikiLinkWarningBody:
+					"위키 링크 안의 외부 URL은 여기서 페이지로 만들어지지 않아요.",
 			},
 			userMenu: {
 				dashboard: "대시보드",
@@ -217,6 +223,8 @@ export const resources = {
 				closePreview: "关闭预览",
 				tryLater: "稍后再试",
 				createPage: "创建页面",
+				wikiLinkWarningTitle: "检测到 Wiki 链接",
+				wikiLinkWarningBody: "Wiki 链接中的外部 URL 不会在这里生成页面。",
 			},
 			userMenu: {
 				dashboard: "仪表盘",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.1.0",
+		"@flowershow/remark-wiki-link": "^3.3.1",
 		"@hugeicons/core-free-icons": "^3.1.1",
 		"@hugeicons/react": "^1.1.4",
 		"@posthog/react": "^1.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@flowershow/remark-wiki-link':
+        specifier: ^3.3.1
+        version: 3.3.1
       '@hugeicons/core-free-icons':
         specifier: ^3.1.1
         version: 3.1.1
@@ -1144,6 +1147,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@flowershow/remark-wiki-link@3.3.1':
+    resolution: {integrity: sha512-kIIbGXZigPU+X3pRn9tgrrnbVAwXi1a6gT9G4NcohJF0+WiReBPOaxa4d7G75+wfXdvw+8dkMUfn1m68qQuPKg==}
 
   '@hugeicons/core-free-icons@3.1.1':
     resolution: {integrity: sha512-UpS2lUQFi5sKyJSWwM6rO+BnPLvVz1gsyCpPHeZyVuZqi89YH8ksliza4cwaODqKOZyeXmG8juo1ty4QtQofkg==}
@@ -4693,6 +4699,12 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@flowershow/remark-wiki-link@3.3.1':
+    dependencies:
+      github-slugger: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-symbol: 2.0.1
 
   '@hugeicons/core-free-icons@3.1.1': {}
 

--- a/server/infra/r2.ts
+++ b/server/infra/r2.ts
@@ -11,6 +11,7 @@ export type R2CustomMetadataInput = {
 	hasCodeBlock?: boolean;
 	hasKatex?: boolean;
 	hasMermaid?: boolean;
+	hasWikiLink?: boolean;
 };
 
 function toR2Metadata(input: R2CustomMetadataInput): Record<string, string> {
@@ -22,6 +23,7 @@ function toR2Metadata(input: R2CustomMetadataInput): Record<string, string> {
 		hasCodeBlock: input.hasCodeBlock ? "1" : "",
 		hasKatex: input.hasKatex ? "1" : "",
 		hasMermaid: input.hasMermaid ? "1" : "",
+		hasWikiLink: input.hasWikiLink ? "1" : "",
 	};
 }
 

--- a/server/repositories/page.repo.ts
+++ b/server/repositories/page.repo.ts
@@ -19,7 +19,9 @@ export function createPageRepo(db: Db) {
 					createdAt: schema.page.createdAt,
 				})
 				.from(schema.page)
-				.where(and(eq(schema.page.userId, userId), isNull(schema.page.deletedAt)))
+				.where(
+					and(eq(schema.page.userId, userId), isNull(schema.page.deletedAt)),
+				)
 				.orderBy(desc(schema.page.createdAt))
 				.limit(30)
 				.all();
@@ -58,7 +60,9 @@ export function createPageRepo(db: Db) {
 			const rows = await db
 				.select({ count: sql<number>`count(*)`.as("count") })
 				.from(schema.page)
-				.where(and(eq(schema.page.userId, userId), isNull(schema.page.deletedAt)))
+				.where(
+					and(eq(schema.page.userId, userId), isNull(schema.page.deletedAt)),
+				)
 				.limit(1)
 				.all();
 			return Number(rows[0]?.count ?? 0);

--- a/server/services/upload.service.ts
+++ b/server/services/upload.service.ts
@@ -150,6 +150,7 @@ export function createUploadService({ env, req, db }: UploadServiceDeps) {
 					hasCodeBlock: metadata.hasCodeBlock,
 					hasKatex: metadata.hasKatex,
 					hasMermaid: metadata.hasMermaid,
+					hasWikiLink: metadata.hasWikiLink,
 				},
 			);
 
@@ -220,6 +221,7 @@ export function createUploadService({ env, req, db }: UploadServiceDeps) {
 					hasCodeBlock: metadata.hasCodeBlock,
 					hasKatex: metadata.hasKatex,
 					hasMermaid: metadata.hasMermaid,
+					hasWikiLink: metadata.hasWikiLink,
 				},
 			).catch(async (error: unknown) => {
 				await pageRepo.deleteById(pageId);

--- a/server/services/view.service.ts
+++ b/server/services/view.service.ts
@@ -12,6 +12,7 @@ type ViewMetadata = {
 	description: string;
 	hasKatex: boolean;
 	hasMermaid: boolean;
+	hasWikiLink: boolean;
 };
 
 type PublicViewResult =
@@ -81,6 +82,7 @@ export function createViewService({ env, db }: { env: Env; db: Db }) {
 				description: object.customMetadata?.description || "",
 				hasKatex: object.customMetadata?.hasKatex === "1",
 				hasMermaid: object.customMetadata?.hasMermaid === "1",
+				hasWikiLink: object.customMetadata?.hasWikiLink === "1",
 			};
 
 			return { kind: "ok", object, html, markdown, meta };

--- a/shared/utils/markdown.spec.ts
+++ b/shared/utils/markdown.spec.ts
@@ -355,5 +355,23 @@ Normal text here.
 			const result = await markdownToHtml(markdown);
 			expect(result.metadata.lang).toBe("en");
 		});
+
+		it("should set hasWikiLink for wiki-style links", async () => {
+			const markdown = "[[Internal link]]";
+			const result = await markdownToHtml(markdown);
+			expect(result.metadata.hasWikiLink).toBe(true);
+		});
+
+		it("should set hasWikiLink for wiki-style embeds", async () => {
+			const markdown = "![[Image.png]]";
+			const result = await markdownToHtml(markdown);
+			expect(result.metadata.hasWikiLink).toBe(true);
+		});
+
+		it("should not set hasWikiLink for regular markdown", async () => {
+			const markdown = "# Heading\n\nJust normal text.";
+			const result = await markdownToHtml(markdown);
+			expect(result.metadata.hasWikiLink).not.toBe(true);
+		});
 	});
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineWorkersConfig(async () => {
 	return {
 		resolve: {
 			alias: {
-				"@": resolve(__dirname, "./server"),
+				"@server": resolve(__dirname, "./server"),
 				"@shared": resolve(__dirname, "./shared"),
 			},
 		},


### PR DESCRIPTION
- Introduced MarkdownParser component to handle file uploads and parse Markdown content.
- Updated PreviewDialog and PreviewPane components to utilize parsed Markdown data.
- Enhanced usePreview hook to support parsed Markdown instead of raw file input.
- Integrated @flowershow/remark-wiki-link for detecting wiki links in Markdown.
- Added localization for wiki link warnings in i18n resources.
- Updated R2 metadata to include hasWikiLink property for better content management.

These changes improve the upload experience by providing real-time Markdown parsing and feedback on wiki links.